### PR TITLE
1114upgrade

### DIFF
--- a/html/ChainFunding.html
+++ b/html/ChainFunding.html
@@ -10,7 +10,7 @@
 </head>
 
 <style>
-    input[type="text"]{padding:10px 30px; border:2px black solid;
+    input[type="text"]{padding:10px 30px; border:2px rgba(12, 0, 0, 0.123) solid;
 border-radius: 20px; }
 </style>
 
@@ -29,8 +29,8 @@ border-radius: 20px; }
           <a href="#">English</a>
         </div>
     </span>
-    <span style="color:white">aaa</span>
-    <span><a href="./login.html"><i class="fa-solid fa-user-plus" style="color:gray;"></i></a> 登入</span>
+    <span style="color:white; user-select: none;" >aaa</span>
+    <span id="main-user-bt" class="dropdown"></span> 
     </header>
     <!-- <table id="SearchConditions" style="text-align: center">
         <tr>
@@ -118,5 +118,6 @@ border-radius: 20px; }
     </footer>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="../html/js/main.js"></script>
+<script src="js/api.js"></script>
 </body>
 </html>

--- a/html/css/ChainFunding.css
+++ b/html/css/ChainFunding.css
@@ -24,6 +24,7 @@ span{
 }
 a{
     font-size: 30px;
+	text-decoration: none;
     font-family:Microsoft JhengHei;
 }
 .header_search

--- a/html/css/fundings.css
+++ b/html/css/fundings.css
@@ -264,3 +264,12 @@ a{
     width: 70%;
     float:right;
 }
+.content_text
+{
+  border-top:12px solid white;
+  border-bottom:12px solid white;
+  padding:8px;
+  background-color: #4a4a4a;
+  text-align:center;
+  color: white;
+}

--- a/html/js/api.js
+++ b/html/js/api.js
@@ -14,7 +14,7 @@ function Registration() {
         "password": password1,
         "re_password": password2
     }
-    console.log(data);
+    //console.log(data);
 
     if (reg1.test(password1)&&(password1==password2)&&(reg2.test(email))){
     }
@@ -25,21 +25,32 @@ function Registration() {
     else if (password1!=password2){
         alert("兩次密碼輸入不一致");
     }
-    
-    var settings = {
-        "url": base_url + "/auth/users/",
-        "method": "POST",
-        "timeout": 0,
-        "headers": {
+    $.ajax({
+        url: base_url + "/auth/users/",
+        method: "POST",
+        timeout: 0,
+        headers: {
             "Content-Type": "application/json",
         },
-    
-        "data": JSON.stringify(data)
-    };
+        data: JSON.stringify(data),
 
-    $.ajax(settings).done(function (response) {
-        console.log(response);
-    });
+        success: function (response) {
+            alert('成功註冊，接下來將為您轉回註冊前界面。');
+            if(document.referrer=="" || document.referrer==document.href){
+                window.location.href = "./ChainFunding.html";
+            }
+            else{
+                window.history.back(-1);
+            }
+        },
+
+        error: function (jqXHR) {
+            if(jqXHR.status=='400'){
+                alert('該帳戶名已被使用，請更換');
+            }
+        }
+    })
+
 }
 
 function Login() {
@@ -60,10 +71,28 @@ function Login() {
             $('#send_data').html(response);
             document.cookie = "refresh="+response.refresh;
             document.cookie = "access="+response.access;
+            alert('成功登入，接下來將為您轉回登入前界面。');
+            if(document.referrer=="" || document.referrer==document.href){
+                window.location.href = "./ChainFunding.html";
+            }
+            else{
+                window.history.back(-1);
+            }
 
         },
-        error: function (xhr) {
-            alert('Ajax request 發生錯誤');
+        error: function (jqXHR) {
+            if(jqXHR.status=='400'){
+                alert('請先輸入您的帳戶和密碼！');
+            }
+            if(jqXHR.status=='401'){
+                alert('您的密碼不正確，或您的帳戶不存在，請重新輸入');
+            }
         }
     })
+}
+
+function Logout(){
+    document.cookie='refresh; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+    document.cookie='access=; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+    location.reload();
 }

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -8,3 +8,19 @@ $("#bars1").click(function(){
     }
     t=1-t;
 });
+
+/*在網頁加載后讀取cookie 決定是顯示登入按鈕還是用戶*/
+
+$(document).ready(function () {
+    var ca=document.cookie.split(';');
+    if(ca.length>1){
+        acc=ca[1].split('=')[1];
+        if (acc!=null){
+            $('#main-user-bt').append("<a href=\"./usermenu.html\">\
+                <i class=\"fa-solid fa-user\" style=\"color:skyblue;\"></i>\個人中心</a>\
+                <div class=\"dropdown-content\"><a href = \"javascript:void(0);\" onclick =\"Logout()\">登出</a></div>");}
+    }
+    else{
+        $('#main-user-bt').append("<a href=\"./login.html\"><i class=\"fa-solid fa-user-plus\" style=\"color:grey;\"></i>登入</a>");
+    }
+});

--- a/html/usermenu.html
+++ b/html/usermenu.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="../html/css/fundings.css">
+    <script src="https://kit.fontawesome.com/d81c0e5457.js" crossorigin="anonymous"></script>
+    <title>ChainFunding | 個人中心</title>
+</head>
+
+<style>
+    input[type="text"]{padding:10px 30px; border:2px rgba(12, 0, 0, 0.123) solid;
+border-radius: 20px; }
+</style>
+
+<body>
+    <header style="text-align:center">
+        <span><a href="./ChainFunding.html"><img src="../html/images/logo.jpeg" align="center"></a></span>
+        <span class="header_search">
+            <!-- <i id="bars1" class="fa-solid fa-bars" style="color: black; font-size:24px;"></i> -->
+            <input type="text" class="search_input" style="font-size: 24px" placeholder="集資項目搜尋">
+            <button class="header_search_button"><button class="header_search_button"><i class="fa-solid fa-magnifying-glass" style="font-size: 24px;color:black;"></i></button></button>
+        </span>
+    <span class="dropdown">
+        <button class="dropbtn"><i class="fa-solid fa-globe" style="color:navy;"></i> 語言</button>
+        <div class="dropdown-content">
+          <a href="#">繁體中文</a>
+          <a href="#">English</a>
+        </div>
+    </span>
+    <span style="color:white; user-select: none;" >aaa</span>
+    <span id="main-user-bt" class="dropdown"></span> 
+    </header>
+    <div class="content_text">個人中心</div>
+    <div class="funding-information">
+        <img src="../html/images/logo.jpeg">
+        <div class="words-message">
+          <hr />
+          <div class="user-username">
+            <span class="info-label-1">用戶名</span>
+            <span class="info-message-1">12345</span>
+          </div>
+          <div class="user-email">
+            <span class="info-label-1">Email地址</span>
+            <span class="info-message-1">12345@gmail.com</span>
+          </div>
+          <div class="user-wallet-bd">
+            <span class="info-label-1">錢包狀態</span>
+            <span class="info-message-1">已綁定</span>
+          </div>
+          <hr />
+          <h4>錢包資訊</h4>
+          <div class="user-balance-1">
+            <span class="info-label-1">WETH</span>
+            <span class="info-message-1" id="weth-balance">0.00</span>
+          </div>
+          <div class="user-balance-2">
+            <span class="info-label-1">USDT</span>
+            <span class="info-message-1" id="usdt-balance">0.00</span>
+          </div>          
+          <div class="user-balance-3">
+            <span class="info-label-1">USDC</span>
+            <span class="info-message-1" id="usdc-balance">0.00</span>
+          </div>
+          <span style="color:white">aaa</span>
+          <div class="user-wallet-address">
+            <span class="info-label-1">已綁定的錢包地址</span>
+            <span class="info-message-1">0x00000</span>
+          </div>
+          <div class="funding buttons">
+            <button class="bt-add-wallet">綁定錢包</button> <!--如果有綁定錢包了 按鈕會變成更改錢包 明天再做-->
+          </div>
+        </div>
+    </div>
+    <footer>   
+        <span class="footer-menu">
+            <div>
+                <a href="https://www.instagram.com/chainfunding_official/"><i class="fa-sharp fa-solid fa-user-secret" style="color:gray;"></i></a>
+                <span>關於我們</span>
+                <span>|</span>
+                <a href="https://www.instagram.com/chainfunding_official/"><i class="fab fa-instagram" style="color:palevioletred;"></i></a>
+                <span>Instagram</span>
+                <span>|</span>
+                <a href="https://www.facebook.com/ChainFunding-103982252340175/"><i class="fab fa-facebook" style="color: blue;"></i></a>
+                <span>Facebook</span>
+            </div>
+        <div>
+            <span>Copyright © 2022 ChainFunding 保留一切權利.</span>
+        </div>
+        </span>
+    </footer>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<script src="../html/js/main.js"></script>
+<script src="js/api.js"></script>
+</body>
+</html>


### PR DESCRIPTION
完善登入和註冊 成功時界面跳轉(上一個界面，如果不存在則跳回首頁) 失敗時跳出失敗訊息
實現登出功能 按下登出 刪除cookie中的access
新增個人中心界面 資料檢視與修改、錢包檢視及設定、加入的項目、追蹤的項目 計劃都放在這個界面 現在比較簡陋

todo:
做錢包餘額相關的api
實現“在未登入狀態下進入某些界面時，需要先去登入界面”
把主頁的功能性微調應用到其它界面